### PR TITLE
feat(#136): use eclipse java formatter instead of google java formatter"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,14 +65,6 @@ SOFTWARE.
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <antlr.version>4.13.2</antlr.version>
-    <argLine>
-        --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
-        --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
-        --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
-        --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
-        --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
-        --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-    </argLine>
   </properties>
   <dependencies>
     <dependency>
@@ -112,11 +104,6 @@ SOFTWARE.
       <version>${antlr.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.google.googlejavaformat</groupId>
-      <artifactId>google-java-format</artifactId>
-      <version>1.24.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>5.11.4</version>
@@ -147,16 +134,6 @@ SOFTWARE.
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.13.0</version>
-        <configuration>
-          <compilerArgs>
-            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
-            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
-            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-          </compilerArgs>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.antlr</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -104,9 +104,9 @@ SOFTWARE.
       <version>${antlr.version}</version>
     </dependency>
     <dependency>
-        <groupId>org.eclipse.jdt</groupId>
-        <artifactId>org.eclipse.jdt.core</artifactId>
-        <version>3.40.0</version>
+      <groupId>org.eclipse.jdt</groupId>
+      <artifactId>org.eclipse.jdt.core</artifactId>
+      <version>3.10.0</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
@@ -161,9 +161,6 @@ SOFTWARE.
         <artifactId>maven-surefire-plugin</artifactId>
         <!-- JUnit 5 requires Surefire version 2.22.0 or higher -->
         <version>3.5.2</version>
-        <configuration>
-          <argLine>@{argLine}</argLine>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,11 @@ SOFTWARE.
       <version>${antlr.version}</version>
     </dependency>
     <dependency>
+        <groupId>org.eclipse.jdt</groupId>
+        <artifactId>org.eclipse.jdt.core</artifactId>
+        <version>3.40.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>5.11.4</version>

--- a/src/main/java/com/github/lombrozo/jsmith/RandomJavaClass.java
+++ b/src/main/java/com/github/lombrozo/jsmith/RandomJavaClass.java
@@ -23,7 +23,9 @@
  */
 package com.github.lombrozo.jsmith;
 
+import com.github.lombrozo.jsmith.antlr.rules.Option;
 import java.util.HashMap;
+import java.util.Optional;
 import org.cactoos.io.ResourceOf;
 import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
@@ -140,8 +142,12 @@ public final class RandomJavaClass {
                 System.lineSeparator()
             );
             final IDocument document = new Document(output);
-            format.apply(document);
-            return document.get();
+            if (format != null) {
+                format.apply(document);
+                return document.get();
+            } else {
+                return output;
+            }
         } catch (final BadLocationException exception) {
             throw new IllegalStateException(
                 String.format("Failed to format source code %n%s%n", output), exception

--- a/src/main/java/com/github/lombrozo/jsmith/RandomJavaClass.java
+++ b/src/main/java/com/github/lombrozo/jsmith/RandomJavaClass.java
@@ -29,6 +29,7 @@ import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
+import org.eclipse.jface.text.IDocument;
 import org.eclipse.text.edits.TextEdit;
 
 /**
@@ -130,12 +131,15 @@ public final class RandomJavaClass {
             new ResourceOf(this.lexer)
         ).generate(this.rule).output();
         try {
-            // Create the code formatter instance
-            CodeFormatter codeFormatter = ToolFactory.createCodeFormatter(new HashMap(0));
-            final TextEdit format = codeFormatter.format(
-                CodeFormatter.K_COMPILATION_UNIT, output, 0, output.length(), 0, null
+            final CodeFormatter formatter = ToolFactory.createCodeFormatter(new HashMap(0));
+            final TextEdit format = formatter.format(
+                CodeFormatter.K_COMPILATION_UNIT, output,
+                0,
+                output.length(),
+                0,
+                System.lineSeparator()
             );
-            final Document document = new Document(output);
+            final IDocument document = new Document(output);
             format.apply(document);
             return document.get();
         } catch (final BadLocationException exception) {

--- a/src/main/java/com/github/lombrozo/jsmith/RandomJavaClass.java
+++ b/src/main/java/com/github/lombrozo/jsmith/RandomJavaClass.java
@@ -23,10 +23,13 @@
  */
 package com.github.lombrozo.jsmith;
 
-import com.google.googlejavaformat.java.Formatter;
-import com.google.googlejavaformat.java.FormatterException;
-import com.google.googlejavaformat.java.JavaFormatterOptions;
+import java.util.HashMap;
 import org.cactoos.io.ResourceOf;
+import org.eclipse.jdt.core.ToolFactory;
+import org.eclipse.jdt.core.formatter.CodeFormatter;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.Document;
+import org.eclipse.text.edits.TextEdit;
 
 /**
  * Random Java class.
@@ -127,8 +130,15 @@ public final class RandomJavaClass {
             new ResourceOf(this.lexer)
         ).generate(this.rule).output();
         try {
-            return new Formatter(JavaFormatterOptions.builder().build()).formatSource(output);
-        } catch (final FormatterException exception) {
+            // Create the code formatter instance
+            CodeFormatter codeFormatter = ToolFactory.createCodeFormatter(new HashMap(0));
+            final TextEdit format = codeFormatter.format(
+                CodeFormatter.K_COMPILATION_UNIT, output, 0, output.length(), 0, null
+            );
+            final Document document = new Document(output);
+            format.apply(document);
+            return document.get();
+        } catch (final BadLocationException exception) {
             throw new IllegalStateException(
                 String.format("Failed to format source code %n%s%n", output), exception
             );

--- a/src/main/java/com/github/lombrozo/jsmith/RandomJavaClass.java
+++ b/src/main/java/com/github/lombrozo/jsmith/RandomJavaClass.java
@@ -23,9 +23,7 @@
  */
 package com.github.lombrozo.jsmith;
 
-import com.github.lombrozo.jsmith.antlr.rules.Option;
 import java.util.HashMap;
-import java.util.Optional;
 import org.cactoos.io.ResourceOf;
 import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
@@ -142,12 +140,14 @@ public final class RandomJavaClass {
                 System.lineSeparator()
             );
             final IDocument document = new Document(output);
+            final String result;
             if (format != null) {
                 format.apply(document);
-                return document.get();
+                result = document.get();
             } else {
-                return output;
+                result = output;
             }
+            return result;
         } catch (final BadLocationException exception) {
             throw new IllegalStateException(
                 String.format("Failed to format source code %n%s%n", output), exception


### PR DESCRIPTION
# Description

In this PR I removed `google-java-format` library and used `eclipse` java formatter due its integration simplicity.

Fixes #136 

# Reviewers

@volodya-lombrozo
