### PR TITLE
Implement RuleBlock class

### DIFF
--- a/src/main/java/com/github/lombrozo/jsmith/antlr/rules/RuleBlock.java
+++ b/src/main/java/com/github/lombrozo/jsmith/antlr/rules/RuleBlock.java
@@ -23,6 +23,11 @@
  */
 package com.github.lombrozo.jsmith.antlr.rules;
 
+import com.github.lombrozo.jsmith.antlr.Context;
+import com.github.lombrozo.jsmith.antlr.view.IntermediateNode;
+import com.github.lombrozo.jsmith.antlr.view.Node;
+import java.util.List;
+
 /**
  * Rule block.
  * The ruleBlock definition in ANTLR grammar:
@@ -33,14 +38,43 @@ package com.github.lombrozo.jsmith.antlr.rules;
  * }
  * @since 0.1
  */
-public final class RuleBlock extends Unimplemented {
+public final class RuleBlock implements Rule {
+    /**
+     * Parent rule.
+     */
+    private final Rule top;
 
     /**
-     * Constructor.
-     * @param parent Parent rule.
+     * RuleAltList.
      */
+    private final Rule list;
+
     public RuleBlock(final Rule parent) {
-        super(parent);
+        this.list = new RuleAltList(this, List.of(new Literal("Empty")));
+        this.top = parent;
+    }
+
+    public RuleBlock(final Rule parent, final Rule list) {
+        this.top = parent;
+        this.list = list;
+    }
+
+    @Override
+    public Rule parent() {
+        return this.top;
+    }
+
+    @Override
+    public Node generate(final Context context) throws WrongPathException {
+        if (!list.name().contains("ruleAltList")) {
+            throw new IllegalStateException("Child of rule block must be RuleAltList");
+        }
+        return new IntermediateNode(this, this.list.generate(context));
+    }
+
+    // Does nothing
+    @Override
+    public void append(final Rule rule) {
     }
 
     @Override
@@ -50,6 +84,6 @@ public final class RuleBlock extends Unimplemented {
 
     @Override
     public Rule copy() {
-        return new RuleBlock(this.parent());
+        return new RuleBlock(this.parent(), this.list.copy());
     }
 }

--- a/src/main/java/com/github/lombrozo/jsmith/antlr/rules/RuleBlock.java
+++ b/src/main/java/com/github/lombrozo/jsmith/antlr/rules/RuleBlock.java
@@ -26,7 +26,6 @@ package com.github.lombrozo.jsmith.antlr.rules;
 import com.github.lombrozo.jsmith.antlr.Context;
 import com.github.lombrozo.jsmith.antlr.view.IntermediateNode;
 import com.github.lombrozo.jsmith.antlr.view.Node;
-import java.util.List;
 
 /**
  * Rule block.
@@ -38,6 +37,7 @@ import java.util.List;
  * }
  * @since 0.1
  */
+@SuppressWarnings("PMD.OnlyOneConstructorShouldDoInitialization")
 public final class RuleBlock implements Rule {
     /**
      * Parent rule.
@@ -49,11 +49,20 @@ public final class RuleBlock implements Rule {
      */
     private final Rule list;
 
+    /**
+     * Constructor.
+     * @param parent Parent rule.
+     */
     public RuleBlock(final Rule parent) {
-        this.list = new RuleAltList(this, List.of(new Literal("Empty")));
         this.top = parent;
+        this.list = new RuleAltList(this);
     }
 
+    /**
+     * Constructor.
+     * @param parent Parent rule.
+     * @param list Rule Alternatives List.
+     */
     public RuleBlock(final Rule parent, final Rule list) {
         this.top = parent;
         this.list = list;
@@ -66,15 +75,15 @@ public final class RuleBlock implements Rule {
 
     @Override
     public Node generate(final Context context) throws WrongPathException {
-        if (!list.name().contains("ruleAltList")) {
+        if (!this.list.name().contains("ruleAltList")) {
             throw new IllegalStateException("Child of rule block must be RuleAltList");
         }
         return new IntermediateNode(this, this.list.generate(context));
     }
 
-    // Does nothing
     @Override
     public void append(final Rule rule) {
+        this.list.append(rule);
     }
 
     @Override

--- a/src/test/java/com/github/lombrozo/jsmith/antlr/rules/RuleBlockTest.java
+++ b/src/test/java/com/github/lombrozo/jsmith/antlr/rules/RuleBlockTest.java
@@ -1,0 +1,44 @@
+package com.github.lombrozo.jsmith.antlr.rules;
+
+import com.github.lombrozo.jsmith.antlr.Context;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+
+/**
+ * Tests for {@link RuleBlock}.
+ *
+ * @since 0.2.0
+ */
+final class RuleBlockTest {
+    @Test
+    void generatesRuleBlock() throws WrongPathException {
+        final RuleBlock block = new RuleBlock(
+            new Root(),
+            new RuleAltList(
+                new Root(),
+                List.of(new Literal("Test1"), new Literal("Test2"))
+            )
+        );
+        MatcherAssert.assertThat(
+            "We expect RuleBlock to generate correctly",
+            block.generate(new Context()).text().output(),
+            Matchers.anyOf(
+                Matchers.equalTo("Test1"),
+                Matchers.equalTo("Test2")
+            )
+        );
+    }
+
+    @Test
+    void throwsIllegalStateException() throws WrongPathException {
+        final RuleBlock block = new RuleBlock(new Root(), new Literal("Invalid"));
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> block.generate(new Context()),
+            "We expect ruleblock to throw exception if child is not RuleAltList class"
+        );
+    }
+}

--- a/src/test/java/com/github/lombrozo/jsmith/antlr/rules/RuleBlockTest.java
+++ b/src/test/java/com/github/lombrozo/jsmith/antlr/rules/RuleBlockTest.java
@@ -38,13 +38,12 @@ import org.junit.jupiter.api.Test;
 final class RuleBlockTest {
     @Test
     void generatesRuleBlock() throws WrongPathException {
-        final RuleBlock block = new RuleBlock(
-            new Root(),
-            new RuleAltList(
-                new Root(),
-                List.of(new Literal("Test1"), new Literal("Test2"))
-            )
+        final RuleBlock block = new RuleBlock(new Root());
+        final RuleAltList rules = new RuleAltList(
+            block,
+            List.of(new Literal("Test1"), new Literal("Test2"))
         );
+        block.append(rules);
         MatcherAssert.assertThat(
             "We expect RuleBlock to generate correctly",
             block.generate(new Context()).text().output(),
@@ -57,11 +56,12 @@ final class RuleBlockTest {
 
     @Test
     void throwsIllegalStateException() throws WrongPathException {
-        final RuleBlock block = new RuleBlock(new Root(), new Literal("Invalid"));
+        final RuleBlock block = new RuleBlock(new Root());
+        final Identifier invalid = new Identifier(block, "Invalid");
         Assertions.assertThrows(
-            IllegalStateException.class,
-            () -> block.generate(new Context()),
-            "We expect ruleblock to throw exception if child is not RuleAltList class"
+            IllegalArgumentException.class,
+            () -> block.append(invalid),
+            "We expect RuleBlock to throw exception if child is not RuleAltList class"
         );
     }
 }

--- a/src/test/java/com/github/lombrozo/jsmith/antlr/rules/RuleBlockTest.java
+++ b/src/test/java/com/github/lombrozo/jsmith/antlr/rules/RuleBlockTest.java
@@ -1,11 +1,34 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023-2025 Volodya Lombrozo
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.github.lombrozo.jsmith.antlr.rules;
 
 import com.github.lombrozo.jsmith.antlr.Context;
+import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import java.util.List;
 
 /**
  * Tests for {@link RuleBlock}.


### PR DESCRIPTION
# Description
Implement RuleBlock class and covered it with tests.
SupressWarnings was used in implementation because I was unable to initialize RuleBlock with and without RuleAltList in one constructor without using if conditions
PR for #88.

# Reviewers

@volodya-lombrozo