### PR TITLE
fix(#158): Fix Flacky Tests by Replacing `Set` with `List`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ antlr-generated/
 *.tokens
 
 src/main/antlr4/com/github/lombrozo/jsmith/tmp
+.aider*

--- a/src/main/java/com/github/lombrozo/jsmith/antlr/semantic/Scope.java
+++ b/src/main/java/com/github/lombrozo/jsmith/antlr/semantic/Scope.java
@@ -25,8 +25,8 @@ package com.github.lombrozo.jsmith.antlr.semantic;
 
 import com.github.lombrozo.jsmith.random.Rand;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.ToString;
@@ -157,28 +157,28 @@ public final class Scope {
      * Get all declared variables.
      * @return All declared variables.
      */
-    private Set<String> allDeclared() {
+    private List<String> allDeclared() {
         return Stream.concat(
             this.variables.allDeclared().stream(),
             Optional.ofNullable(this.parent)
                 .map(Scope::allDeclared)
                 .stream()
                 .flatMap(Collection::stream)
-        ).collect(Collectors.toSet());
+        ).collect(Collectors.toList());
     }
 
     /**
      * Get all assigned variables.
      * @return All assigned variables.
      */
-    private Set<String> allAssigned() {
+    private List<String> allAssigned() {
         return Stream.concat(
             this.variables.allAssigned().stream(),
             Optional.ofNullable(this.parent)
                 .map(Scope::allAssigned)
                 .stream()
                 .flatMap(Collection::stream)
-        ).collect(Collectors.toSet());
+        ).collect(Collectors.toList());
     }
 
     /**
@@ -186,7 +186,7 @@ public final class Scope {
      * @param collection Collection.
      * @return Random element.
      */
-    private Optional<String> random(final Set<String> collection) {
+    private Optional<String> random(final List<String> collection) {
         final Optional<String> result;
         if (collection.isEmpty()) {
             result = Optional.empty();

--- a/src/main/java/com/github/lombrozo/jsmith/antlr/semantic/Variables.java
+++ b/src/main/java/com/github/lombrozo/jsmith/antlr/semantic/Variables.java
@@ -23,9 +23,8 @@
  */
 package com.github.lombrozo.jsmith.antlr.semantic;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.ToString;
@@ -40,12 +39,12 @@ public final class Variables {
     /**
      * Declared variables.
      */
-    private final Set<Variable> decl;
+    private final List<Variable> decl;
 
     /**
      * Assigned variables.
      */
-    private final Set<Variable> init;
+    private final List<Variable> init;
 
     /**
      * Default constructor.
@@ -53,8 +52,8 @@ public final class Variables {
      */
     public Variables() {
         this(
-            new HashSet<>(0),
-            new HashSet<>(0)
+            new ArrayList<>(0),
+            new ArrayList<>(0)
         );
     }
 
@@ -64,8 +63,8 @@ public final class Variables {
      * @param declared Declared variables.
      */
     public Variables(
-        final Set<Variable> assigned,
-        final Set<Variable> declared
+        final List<Variable> assigned,
+        final List<Variable> declared
     ) {
         this.init = assigned;
         this.decl = declared;
@@ -129,10 +128,10 @@ public final class Variables {
      * @param type Variable type.
      * @return All assigned variables.
      */
-    Set<String> allAssigned(final String type) {
+    List<String> allAssigned(final String type) {
         return this.init.stream()
             .filter(v -> v.type().equals(type))
             .map(Variable::name)
-            .collect(Collectors.toSet());
+            .collect(Collectors.toList());
     }
 }

--- a/src/test/java/com/github/lombrozo/jsmith/RandomJavaClassTest.java
+++ b/src/test/java/com/github/lombrozo/jsmith/RandomJavaClassTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test cases for {@link RandomJavaClass}.
@@ -67,6 +68,21 @@ final class RandomJavaClassTest {
         );
     }
 
+    @ParameterizedTest
+    @ValueSource(longs = {1_038_792_632_350_611_846L, 2_257_151_642_642_236_899L})
+    void generatesSameSrcWithSeed(final long seed) {
+        final Params params = new Params(seed);
+        final RandomJavaClass clazz = new RandomJavaClass(params);
+        MatcherAssert.assertThat(
+            String.format(
+                "We expect that the generated source code will be the same, but they weren't '%s'",
+                params
+            ),
+            clazz.src(),
+            Matchers.equalTo(clazz.src())
+        );
+    }
+
     @Test
     void generatesJavaCodeWithTheSameSeedAndParam() {
         final long seed = -4_887_843_732_314_896_880L;
@@ -77,11 +93,10 @@ final class RandomJavaClassTest {
         );
     }
 
-    @Test
-    void generatesSpecificJavaClass() {
-        final String src = new RandomJavaClass(
-            new Params(7_648_701_033_033_712_484L)
-        ).src();
+    @ParameterizedTest
+    @ValueSource(longs = {1_038_792_632_350_611_846L, 2_257_151_642_642_236_899L})
+    void generatesSpecificJavaClass(final long seed) {
+        final String src = new RandomJavaClass(new Params(seed)).src();
         Logger.info(this, "Generated source code: %n%s%n", src);
         Assertions.assertDoesNotThrow(
             () -> new InMemoryCompiler().compile(src),


### PR DESCRIPTION
This pull request refactors the `Scope` and `Variables` classes to use `List` instead of `Set` for storing variables. Additionally, it enhances the `RandomJavaClassTest` by adding parameterized tests to ensure consistent source code generation with specific seeds.

Closes #158