### PR TITLE
ci(#171): Update Ubuntu runner from 20.04 to 24.04

### DIFF
--- a/.github/workflows/maven.test.yaml
+++ b/.github/workflows/maven.test.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2022, macos-14]
+        os: [ubuntu-24.04, windows-2022, macos-14]
         java: [11, 17]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ antlr-generated/
 
 src/main/antlr4/com/github/lombrozo/jsmith/tmp
 .aider*
+.aidy


### PR DESCRIPTION
Updates CI workflow to use `ubuntu-24.04` runner and adds `.aidy` to `.gitignore`.

Closes #171